### PR TITLE
Switch from overlap.difference to overlap.tail

### DIFF
--- a/lib/defiled.js
+++ b/lib/defiled.js
@@ -5,7 +5,7 @@ var overlap = require('file-overlap');
 
 var File = function File(file, dir) {
   this._dir = dir || process.cwd();
-  this._file = overlap.difference(file, this._dir);
+  this._file = overlap.tail(file, this._dir);
   this.transformers = _.clone(transformers);
 };
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/tandrewnichols/defiled",
   "dependencies": {
-    "file-overlap": "^1.0.0",
+    "file-overlap": "^1.1.0",
     "lodash": "^3.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`overlap.difference` gets confused if the same directory name occurs in multiple places. For instance, on Linux, you can't have a `home` folder for code related to a project home page because the root directory for uses is called `home`, so it ended up getting chopped off incorrectly. Using `tail` _should_ fix this.